### PR TITLE
refactor: separa os icones sociais do hero.

### DIFF
--- a/src/components/Box/styles.ts
+++ b/src/components/Box/styles.ts
@@ -14,6 +14,7 @@ export const BoxContent = styled(FlexComponent)<BorderType>`
     height: 100%;
     padding: ${padding};
     color: ${theme.colors.gray[200]};
+    border: 1px solid transparent;
 
     svg {
       font-size: inherit;

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -1,12 +1,6 @@
 import Image from 'next/image';
-import {
-  GithubLogo,
-  InstagramLogo,
-  LinkedinLogo,
-  TwitterLogo
-} from 'phosphor-react';
 
-import { Box, Flex } from '@/components';
+import { Box, Flex, SocialIcons } from '@/components';
 
 import * as S from './styles';
 
@@ -98,48 +92,7 @@ const Hero = () => {
           Node
         </Box>
 
-        <S.HeroSocialWrapper>
-          <Box
-            splitChildren={<InstagramLogo size={24} />}
-            contentAlign="center"
-            justifySplit="center"
-            area="in"
-            borderbat="top"
-            borderlar="left"
-          >
-            <InstagramLogo size={24} />
-          </Box>
-          <Box
-            splitChildren={<LinkedinLogo size={24} />}
-            contentAlign="center"
-            justifySplit="center"
-            area="lk"
-            borderbat="top"
-            borderlar="left"
-          >
-            <LinkedinLogo size={24} />
-          </Box>
-          <Box
-            splitChildren={<GithubLogo size={24} />}
-            contentAlign="center"
-            justifySplit="center"
-            area="gh"
-            borderbat="top"
-            borderlar="left"
-          >
-            <GithubLogo size={24} />
-          </Box>
-          <Box
-            splitChildren={<TwitterLogo size={24} />}
-            contentAlign="center"
-            justifySplit="center"
-            area="tw"
-            borderbat="top"
-            borderlar="left"
-          >
-            <TwitterLogo size={24} />
-          </Box>
-        </S.HeroSocialWrapper>
+        <SocialIcons />
       </S.LastColumn>
     </S.HeroContent>
   );

--- a/src/components/SocialIcons/index.tsx
+++ b/src/components/SocialIcons/index.tsx
@@ -1,0 +1,81 @@
+import Link from 'next/link';
+import {
+  GithubLogo,
+  InstagramLogo,
+  LinkedinLogo,
+  TwitterLogo
+} from 'phosphor-react';
+
+import { Box } from '@/components';
+
+import { SOCIAL_URL } from '@/utils/common/constant';
+
+import * as S from './styles';
+
+const SocialIcons = () => {
+  return (
+    <S.SocialIconsContentContent>
+      <Link href={SOCIAL_URL.GITHUB} target="_blank" rel="noopener noreferrer">
+        <Box
+          splitChildren={<GithubLogo size={24} />}
+          contentAlign="center"
+          justifySplit="center"
+          area="gh"
+          borderbat="top"
+          borderlar="left"
+        >
+          <GithubLogo size={24} />
+        </Box>
+      </Link>
+
+      <Link
+        href={SOCIAL_URL.INSTAGRAM}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Box
+          splitChildren={<InstagramLogo size={24} />}
+          contentAlign="center"
+          justifySplit="center"
+          area="in"
+          borderbat="top"
+          borderlar="left"
+        >
+          <InstagramLogo size={24} />
+        </Box>
+      </Link>
+
+      <Link
+        href={SOCIAL_URL.LINKEDIN}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Box
+          splitChildren={<LinkedinLogo size={24} />}
+          contentAlign="center"
+          justifySplit="center"
+          area="lk"
+          borderbat="top"
+          borderlar="left"
+        >
+          <LinkedinLogo size={24} />
+        </Box>
+      </Link>
+
+      <Link href={SOCIAL_URL.TWITTER} target="_blank" rel="noopener noreferrer">
+        <Box
+          splitChildren={<TwitterLogo size={24} />}
+          contentAlign="center"
+          justifySplit="center"
+          area="tw"
+          borderbat="top"
+          borderlar="left"
+        >
+          <TwitterLogo size={24} />
+        </Box>
+      </Link>
+    </S.SocialIconsContentContent>
+  );
+};
+
+export default SocialIcons;

--- a/src/components/SocialIcons/styles.ts
+++ b/src/components/SocialIcons/styles.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import styled from 'styled-components';
+
+export const SocialIconsContentContent = styled.div`
+  display: none;
+
+  @media (min-width: 992px) {
+    width: 100%;
+    display: initial;
+    grid-area: social-icons;
+
+    display: grid;
+    grid-auto-columns: 1fr;
+    grid-template-columns: repeat(4, 1fr);
+    grid-template-areas: 'in lk gh tw';
+  }
+`;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export { default as Box } from './Box';
 export { FlexComponent as Flex } from './Flex';
 export { default as Hero } from './Hero';
+export { default as SocialIcons } from './SocialIcons';
 export { default as Split } from './Split';

--- a/src/utils/common/constant/index.ts
+++ b/src/utils/common/constant/index.ts
@@ -1,0 +1,6 @@
+export const SOCIAL_URL = {
+  GITHUB: 'https://github.com/dfsilvadev',
+  INSTAGRAM: 'https://www.instagram.com/dfsilva.dev/',
+  LINKEDIN: 'https://www.linkedin.com/in/dfsilva-dev/',
+  TWITTER: 'https://twitter.com/dfsilvadev'
+};


### PR DESCRIPTION
### 🔨 O que esse PR faz?

Este PR refatora o componente Hero separando os links das redes sociais e criando um wrapper separado para eles. 

### 🔗 Referências

[FIGMA](https://www.figma.com/proto/cfKcBrLbPGQHZWvyR3OPBQ/Portf%C3%B3lio-v2?page-id=0%3A1&type=design&node-id=501-54&viewport=-1651%2C-990%2C0.98&t=lQS8YPniNfAWDjkO-1&scaling=scale-down&starting-point-node-id=501%3A54&mode=design)

### 📗 Prints

### 📗 Checklist do desenvolvedor

- [ ] Foi adicionado o arquivo de changelog?
- [ ] Foi criado testes para a solução?
- [ ] Foi criado ou atualizado as documentações?
